### PR TITLE
GPU: naïve D3D11 implementation

### DIFF
--- a/Cpp/Source/Config.h
+++ b/Cpp/Source/Config.h
@@ -4,7 +4,10 @@
 
 #define DO_SAMPLES_PER_PIXEL 4
 #define DO_ANIMATE 0
-#define DO_ANIMATE_SMOOTHING 0.5f
+#define DO_ANIMATE_SMOOTHING 0.9f
 #define DO_LIGHT_SAMPLING 1
 #define DO_PROGRESSIVE 1
 #define DO_MITSUBA_COMPARE 0
+
+#define kCSGroupSizeX 16
+#define kCSGroupSizeY 16

--- a/Cpp/Windows/ComputeShader.hlsl
+++ b/Cpp/Windows/ComputeShader.hlsl
@@ -1,0 +1,375 @@
+#include "../Source/Config.h"
+
+inline uint RNG(inout uint state)
+{
+    uint x = state;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 15;
+    state = x;
+    return x;
+}
+
+float RandomFloat01(inout uint state)
+{
+    return (RNG(state) & 0xFFFFFF) / 16777216.0f;
+}
+
+float3 RandomInUnitDisk(inout uint state)
+{
+    float a = RandomFloat01(state) * 2.0f * 3.1415926f;
+    float2 xy = float2(cos(a), sin(a));
+    xy *= sqrt(RandomFloat01(state));
+    return float3(xy, 0);
+}
+float3 RandomInUnitSphere(inout uint state)
+{
+    float z = RandomFloat01(state) * 2.0f - 1.0f;
+    float t = RandomFloat01(state) * 2.0f * 3.1415926f;
+    float r = sqrt(max(0.0, 1.0f - z * z));
+    float x = r * cos(t);
+    float y = r * sin(t);
+    float3 res = float3(x, y, z);
+    res *= pow(RandomFloat01(state), 1.0 / 3.0);
+    return res;
+}
+float3 RandomUnitVector(inout uint state)
+{
+    float z = RandomFloat01(state) * 2.0f - 1.0f;
+    float a = RandomFloat01(state) * 2.0f * 3.1415926f;
+    float r = sqrt(1.0f - z * z);
+    float x = r * cos(a);
+    float y = r * sin(a);
+    return float3(x, y, z);
+}
+
+
+
+struct Ray
+{
+    float3 orig;
+    float3 dir;
+};
+Ray MakeRay(float3 orig_, float3 dir_) { Ray r; r.orig = orig_; r.dir = dir_; return r; }
+float3 RayPointAt(Ray r, float t) { return r.orig + r.dir * t; }
+
+
+inline bool refract(float3 v, float3 n, float nint, out float3 outRefracted)
+{
+    float dt = dot(v, n);
+    float discr = 1.0f - nint * nint*(1 - dt * dt);
+    if (discr > 0)
+    {
+        outRefracted = nint * (v - n * dt) - n * sqrt(discr);
+        return true;
+    }
+    return false;
+}
+inline float schlick(float cosine, float ri)
+{
+    float r0 = (1 - ri) / (1 + ri);
+    r0 = r0 * r0;
+    return r0 + (1 - r0)*pow(1 - cosine, 5);
+}
+
+struct Hit
+{
+    float3 pos;
+    float3 normal;
+    float t;
+};
+
+struct Sphere
+{
+    float3 center;
+    float radius;
+    float invRadius;
+};
+
+#define MatLambert 0
+#define MatMetal 1
+#define MatDielectric 2
+
+struct Material
+{
+    int type;
+    float3 albedo;
+    float3 emissive;
+    float roughness;
+    float ri;
+};
+
+struct Camera
+{
+    float3 origin;
+    float3 lowerLeftCorner;
+    float3 horizontal;
+    float3 vertical;
+    float3 u, v, w;
+    float lensRadius;
+};
+
+Ray CameraGetRay(Camera cam, float s, float t, inout uint state)
+{
+    float3 rd = cam.lensRadius * RandomInUnitDisk(state);
+    float3 offset = cam.u * rd.x + cam.v * rd.y;
+    return MakeRay(cam.origin + offset, normalize(cam.lowerLeftCorner + s * cam.horizontal + t * cam.vertical - cam.origin - offset));
+}
+
+
+bool HitSphere(Ray r, Sphere s, float tMin, float tMax, inout Hit outHit)
+{
+    float3 oc = r.orig - s.center;
+    float b = dot(oc, r.dir);
+    float c = dot(oc, oc) - s.radius*s.radius;
+    float discr = b * b - c;
+    if (discr > 0)
+    {
+        float discrSq = sqrt(discr);
+
+        float t = (-b - discrSq);
+        if (t < tMax && t > tMin)
+        {
+            outHit.pos = RayPointAt(r, t);
+            outHit.normal = (outHit.pos - s.center) * s.invRadius;
+            outHit.t = t;
+            return true;
+        }
+        t = (-b + discrSq);
+        if (t < tMax && t > tMin)
+        {
+            outHit.pos = RayPointAt(r, t);
+            outHit.normal = (outHit.pos - s.center) * s.invRadius;
+            outHit.t = t;
+            return true;
+        }
+    }
+    return false;
+}
+
+struct Params
+{
+    Camera cam;
+    int sphereCount;
+    int screenWidth;
+    int screenHeight;
+    int frames;
+    float invWidth;
+    float invHeight;
+    float lerpFac;
+};
+
+
+#define kMinT 0.001f
+#define kMaxT 1.0e7f
+#define kMaxDepth 10
+
+
+static int HitWorld(StructuredBuffer<Sphere> spheres, int sphereCount, Ray r, float tMin, float tMax, inout Hit outHit)
+{
+    Hit tmpHit;
+    int id = -1;
+    float closest = tMax;
+    for (int i = 0; i < sphereCount; ++i)
+    {
+        if (HitSphere(r, spheres[i], tMin, closest, tmpHit))
+        {
+            closest = tmpHit.t;
+            outHit = tmpHit;
+            id = i;
+        }
+    }
+    return id;
+}
+
+
+static bool Scatter(StructuredBuffer<Sphere> spheres, StructuredBuffer<Material> materials, int sphereCount, int matID, Ray r_in, Hit rec, out float3 attenuation, out Ray scattered, out float3 outLightE, inout int inoutRayCount, inout uint state)
+{
+    outLightE = float3(0, 0, 0);
+    Material mat = materials[matID];
+    if (mat.type == MatLambert)
+    {
+        // random point on unit sphere that is tangent to the hit point
+        float3 target = rec.pos + rec.normal + RandomUnitVector(state);
+        scattered = MakeRay(rec.pos, normalize(target - rec.pos));
+        attenuation = mat.albedo;
+
+        // sample lights
+#if DO_LIGHT_SAMPLING
+        for (int i = 0; i < sphereCount; ++i)
+        {
+            Material smat = materials[i];
+            float3 smatE = smat.emissive;
+            if (smatE.x <= 0 && smatE.y <= 0 && smatE.z <= 0)
+                continue; // skip non-emissive
+            if (matID == i)
+                continue; // skip self
+            Sphere s = spheres[i];
+
+            // create a random direction towards sphere
+            // coord system for sampling: sw, su, sv
+            float3 sw = normalize(s.center - rec.pos);
+            float3 su = normalize(cross(abs(sw.x)>0.01f ? float3(0, 1, 0) : float3(1, 0, 0), sw));
+            float3 sv = cross(sw, su);
+            // sample sphere by solid angle
+            float cosAMax = sqrt(1.0f - s.radius*s.radius / dot(rec.pos - s.center, rec.pos - s.center));
+            float eps1 = RandomFloat01(state), eps2 = RandomFloat01(state);
+            float cosA = 1.0f - eps1 + eps1 * cosAMax;
+            float sinA = sqrt(1.0f - cosA * cosA);
+            float phi = 2 * 3.1415926 * eps2;
+            float3 l = su * cos(phi) * sinA + sv * sin(phi) * sinA + sw * cosA;
+            l = normalize(l);
+
+            // shoot shadow ray
+            Hit lightHit;
+            ++inoutRayCount;
+            int hitID = HitWorld(spheres, sphereCount, MakeRay(rec.pos, l), kMinT, kMaxT, lightHit);
+            if (hitID == i)
+            {
+                float omega = 2 * 3.1415926 * (1 - cosAMax);
+
+                float3 rdir = r_in.dir;
+                float3 nl = dot(rec.normal, rdir) < 0 ? rec.normal : -rec.normal;
+                outLightE += (mat.albedo * smat.emissive) * (max(0.0f, dot(l, nl)) * omega / 3.1415926);
+            }
+        }
+#endif
+        return true;
+    }
+    else if (mat.type == MatMetal)
+    {
+        float3 refl = reflect(r_in.dir, rec.normal);
+        // reflected ray, and random inside of sphere based on roughness
+        float roughness = mat.roughness;
+#if DO_MITSUBA_COMPARE
+        roughness = 0; // until we get better BRDF for metals
+#endif
+        scattered = MakeRay(rec.pos, normalize(refl + roughness*RandomInUnitSphere(state)));
+        attenuation = mat.albedo;
+        return dot(scattered.dir, rec.normal) > 0;
+    }
+    else if (mat.type == MatDielectric)
+    {
+        float3 outwardN;
+        float3 rdir = r_in.dir;
+        float3 refl = reflect(rdir, rec.normal);
+        float nint;
+        attenuation = float3(1, 1, 1);
+        float3 refr;
+        float reflProb;
+        float cosine;
+        if (dot(rdir, rec.normal) > 0)
+        {
+            outwardN = -rec.normal;
+            nint = mat.ri;
+            cosine = mat.ri * dot(rdir, rec.normal);
+        }
+        else
+        {
+            outwardN = rec.normal;
+            nint = 1.0f / mat.ri;
+            cosine = -dot(rdir, rec.normal);
+        }
+        if (refract(rdir, outwardN, nint, refr))
+        {
+            reflProb = schlick(cosine, mat.ri);
+        }
+        else
+        {
+            reflProb = 1;
+        }
+        if (RandomFloat01(state) < reflProb)
+            scattered = MakeRay(rec.pos, normalize(refl));
+        else
+            scattered = MakeRay(rec.pos, normalize(refr));
+    }
+    else
+    {
+        attenuation = float3(1, 0, 1);
+        scattered = MakeRay(float3(0,0,0), float3(0, 0, 1));
+        return false;
+    }
+    return true;
+}
+
+static float3 Trace(StructuredBuffer<Sphere> spheres, StructuredBuffer<Material> materials, int sphereCount, Ray r, inout int inoutRayCount, inout uint state)
+{
+    float3 col = 0;
+    float3 curAtten = 1;
+    bool doMaterialE = true;
+    for (int depth = 0; depth < kMaxDepth; ++depth)
+    {
+        Hit rec;
+        ++inoutRayCount;
+        int id = HitWorld(spheres, sphereCount, r, kMinT, kMaxT, rec);
+        if (id >= 0)
+        {
+            Ray scattered;
+            float3 attenuation;
+            float3 lightE;
+            Material mat = materials[id];
+            float3 matE = mat.emissive;
+            if (Scatter(spheres, materials, sphereCount, id, r, rec, attenuation, scattered, lightE, inoutRayCount, state))
+            {
+#if DO_LIGHT_SAMPLING
+                if (!doMaterialE) matE = 0;
+                doMaterialE = (mat.type != MatLambert);
+#endif
+                col += curAtten * (matE + lightE);
+                curAtten *= attenuation;
+                r = scattered;
+            }
+            else
+            {
+                col += curAtten * matE;
+                break;
+            }
+        }
+        else
+        {
+            // sky
+#if DO_MITSUBA_COMPARE
+            col += curAtten * float3(0.15f, 0.21f, 0.3f); // easier compare with Mitsuba's constant environment light
+#else
+
+            float3 unitDir = r.dir;
+            float t = 0.5f*(unitDir.y + 1.0f);
+            float3 skyCol = ((1.0f - t)*float3(1.0f, 1.0f, 1.0f) + t * float3(0.5f, 0.7f, 1.0f)) * 0.3f;
+            col += curAtten * skyCol;
+#endif
+            break;
+        }
+    }
+    return col;
+}
+
+Texture2D srcImage : register(t0);
+RWTexture2D<float4> dstImage : register(u0);
+StructuredBuffer<Sphere> g_Spheres : register(t1);
+StructuredBuffer<Material> g_Materials : register(t2);
+StructuredBuffer<Params> g_Params : register(t3);
+RWByteAddressBuffer g_OutRayCount : register(u1);
+
+[numthreads(kCSGroupSizeX, kCSGroupSizeY, 1)]
+void main(
+    uint3 gid : SV_DispatchThreadID)
+{
+    int rayCount = 0;
+    float3 col = 0;
+    Params params = g_Params[0];
+    uint rngState = (gid.x * 1973 + gid.y * 9277 + params.frames * 26699) | 1;
+    for (int s = 0; s < DO_SAMPLES_PER_PIXEL; s++)
+    {
+        float u = float(gid.x + RandomFloat01(rngState)) * params.invWidth;
+        float v = float(gid.y + RandomFloat01(rngState)) * params.invHeight;
+        Ray r = CameraGetRay(params.cam, u, v, rngState);
+        col += Trace(g_Spheres, g_Materials, params.sphereCount, r, rayCount, rngState);
+    }
+    col *= 1.0f / float(DO_SAMPLES_PER_PIXEL);
+
+    float3 prev = srcImage.Load(int3(gid.xy,0)).rgb;
+    col = lerp(col, prev, params.lerpFac);
+    dstImage[gid.xy] = float4(col, 1);
+    uint prevRayCount;
+    g_OutRayCount.InterlockedAdd(0, rayCount, prevRayCount);
+}

--- a/Cpp/Windows/TestCpu.vcxproj
+++ b/Cpp/Windows/TestCpu.vcxproj
@@ -172,6 +172,24 @@
     <None Include="..\.editorconfig" />
   </ItemGroup>
   <ItemGroup>
+    <FxCompile Include="ComputeShader.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Compute</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Compute</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">5.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Compute</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Compute</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">5.0</ShaderModel>
+      <VariableName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">g_CSBytecode</VariableName>
+      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompiledComputeShader.h</HeaderFileOutput>
+      <VariableName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">g_CSBytecode</VariableName>
+      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompiledComputeShader.h</HeaderFileOutput>
+      <VariableName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">g_CSBytecode</VariableName>
+      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompiledComputeShader.h</HeaderFileOutput>
+      <VariableName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">g_CSBytecode</VariableName>
+      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompiledComputeShader.h</HeaderFileOutput>
+    </FxCompile>
     <FxCompile Include="PixelShader.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>

--- a/Cpp/Windows/TestCpu.vcxproj.filters
+++ b/Cpp/Windows/TestCpu.vcxproj.filters
@@ -58,5 +58,6 @@
   <ItemGroup>
     <FxCompile Include="VertexShader.hlsl" />
     <FxCompile Include="PixelShader.hlsl" />
+    <FxCompile Include="ComputeShader.hlsl" />
   </ItemGroup>
 </Project>

--- a/Cpp/Windows/TestWin.cpp
+++ b/Cpp/Windows/TestWin.cpp
@@ -4,12 +4,16 @@
 #include <windows.h>
 #include <d3d11_1.h>
 
+#define DO_COMPUTE 1
+
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 #include <algorithm>
 
 #include "../Source/Config.h"
+#include "../Source/Maths.h"
 #include "../Source/Test.h"
 #include "CompiledVertexShader.h"
 #include "CompiledPixelShader.h"
@@ -35,11 +39,35 @@ static IDXGISwapChain* g_D3D11SwapChain = nullptr;
 static ID3D11RenderTargetView* g_D3D11RenderTarget = nullptr;
 static ID3D11VertexShader* g_VertexShader;
 static ID3D11PixelShader* g_PixelShader;
-static ID3D11Texture2D* g_BackbufferTexture;
-static ID3D11ShaderResourceView* g_BackbufferSRV;
+static ID3D11Texture2D *g_BackbufferTexture, *g_BackbufferTexture2;
+static ID3D11ShaderResourceView *g_BackbufferSRV, *g_BackbufferSRV2;
+static ID3D11UnorderedAccessView *g_BackbufferUAV, *g_BackbufferUAV2;
 static ID3D11SamplerState* g_SamplerLinear;
 static ID3D11RasterizerState* g_RasterState;
+static int g_BackbufferIndex;
 
+
+#if DO_COMPUTE
+#include "CompiledComputeShader.h"
+struct ComputeParams
+{
+    Camera cam;
+    int sphereCount;
+    int screenWidth;
+    int screenHeight;
+    int frames;
+    float invWidth;
+    float invHeight;
+    float lerpFac;
+};
+static ID3D11ComputeShader* g_ComputeShader;
+static ID3D11Buffer* g_DataSpheres;     static ID3D11ShaderResourceView* g_SRVSpheres;
+static ID3D11Buffer* g_DataMaterials;   static ID3D11ShaderResourceView* g_SRVMaterials;
+static ID3D11Buffer* g_DataParams;      static ID3D11ShaderResourceView* g_SRVParams;
+static ID3D11Buffer* g_DataCounter;     static ID3D11UnorderedAccessView* g_UAVCounter;
+static int g_SphereCount, g_ObjSize, g_MatSize;
+static ID3D11Query *g_QueryBegin, *g_QueryEnd, *g_QueryDisjoint;
+#endif // #if DO_COMPUTE
 
 int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR, _In_ int nCmdShow)
 {
@@ -62,6 +90,9 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR,
 
     g_D3D11Device->CreateVertexShader(g_VSBytecode, ARRAYSIZE(g_VSBytecode), NULL, &g_VertexShader);
     g_D3D11Device->CreatePixelShader(g_PSBytecode, ARRAYSIZE(g_PSBytecode), NULL, &g_PixelShader);
+#if DO_COMPUTE
+    g_D3D11Device->CreateComputeShader(g_CSBytecode, ARRAYSIZE(g_CSBytecode), NULL, &g_ComputeShader);
+#endif
 
     D3D11_TEXTURE2D_DESC texDesc = {};
     texDesc.Width = kBackbufferWidth;
@@ -71,11 +102,18 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR,
     texDesc.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
     texDesc.SampleDesc.Count = 1;
     texDesc.SampleDesc.Quality = 0;
+#if DO_COMPUTE
+    texDesc.Usage = D3D11_USAGE_DEFAULT;
+    texDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+    texDesc.CPUAccessFlags = 0;
+#else
     texDesc.Usage = D3D11_USAGE_DYNAMIC;
     texDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
     texDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+#endif
     texDesc.MiscFlags = 0;
     g_D3D11Device->CreateTexture2D(&texDesc, NULL, &g_BackbufferTexture);
+    g_D3D11Device->CreateTexture2D(&texDesc, NULL, &g_BackbufferTexture2);
 
     D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
     srvDesc.Format = texDesc.Format;
@@ -83,6 +121,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR,
     srvDesc.Texture2D.MipLevels = 1;
     srvDesc.Texture2D.MostDetailedMip = 0;
     g_D3D11Device->CreateShaderResourceView(g_BackbufferTexture, &srvDesc, &g_BackbufferSRV);
+    g_D3D11Device->CreateShaderResourceView(g_BackbufferTexture2, &srvDesc, &g_BackbufferSRV2);
 
     D3D11_SAMPLER_DESC smpDesc = {};
     smpDesc.Filter = D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
@@ -93,6 +132,67 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR,
     rasterDesc.FillMode = D3D11_FILL_SOLID;
     rasterDesc.CullMode = D3D11_CULL_NONE;
     g_D3D11Device->CreateRasterizerState(&rasterDesc, &g_RasterState);
+
+#if DO_COMPUTE
+    D3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+
+    int camSize;
+    GetObjectCount(g_SphereCount, g_ObjSize, g_MatSize, camSize);
+    assert(g_ObjSize == 20);
+    assert(g_MatSize == 36);
+    assert(camSize == 88);
+    D3D11_BUFFER_DESC bdesc = {};
+    bdesc.ByteWidth = g_SphereCount * g_ObjSize;
+    bdesc.Usage = D3D11_USAGE_DEFAULT;
+    bdesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+    bdesc.CPUAccessFlags = 0;
+    bdesc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+    bdesc.StructureByteStride = g_ObjSize;
+    g_D3D11Device->CreateBuffer(&bdesc, NULL, &g_DataSpheres);
+    srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+    srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
+    srvDesc.Buffer.FirstElement = 0;
+    srvDesc.Buffer.NumElements = g_SphereCount;
+    g_D3D11Device->CreateShaderResourceView(g_DataSpheres, &srvDesc, &g_SRVSpheres);
+
+    bdesc.ByteWidth = g_SphereCount * g_MatSize;
+    bdesc.StructureByteStride = g_MatSize;
+    g_D3D11Device->CreateBuffer(&bdesc, NULL, &g_DataMaterials);
+    srvDesc.Buffer.NumElements = g_SphereCount;
+    g_D3D11Device->CreateShaderResourceView(g_DataMaterials, &srvDesc, &g_SRVMaterials);
+
+    bdesc.ByteWidth = sizeof(ComputeParams);
+    bdesc.StructureByteStride = sizeof(ComputeParams);
+    g_D3D11Device->CreateBuffer(&bdesc, NULL, &g_DataParams);
+    srvDesc.Buffer.NumElements = 1;
+    g_D3D11Device->CreateShaderResourceView(g_DataParams, &srvDesc, &g_SRVParams);
+
+    bdesc.ByteWidth = 4;
+    bdesc.BindFlags |= D3D11_BIND_UNORDERED_ACCESS;
+    bdesc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS;
+    bdesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+    g_D3D11Device->CreateBuffer(&bdesc, NULL, &g_DataCounter);
+    uavDesc.Format = DXGI_FORMAT_R32_TYPELESS;
+    uavDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
+    uavDesc.Buffer.FirstElement = 0;
+    uavDesc.Buffer.NumElements = 1;
+    uavDesc.Buffer.Flags = D3D11_BUFFER_UAV_FLAG_RAW;
+    g_D3D11Device->CreateUnorderedAccessView(g_DataCounter, &uavDesc, &g_UAVCounter);
+
+    uavDesc.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+    uavDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D;
+    uavDesc.Texture2D.MipSlice = 0;
+    g_D3D11Device->CreateUnorderedAccessView(g_BackbufferTexture, &uavDesc, &g_BackbufferUAV);
+    g_D3D11Device->CreateUnorderedAccessView(g_BackbufferTexture2, &uavDesc, &g_BackbufferUAV2);
+
+    D3D11_QUERY_DESC qDesc = {};
+    qDesc.Query = D3D11_QUERY_TIMESTAMP;
+    g_D3D11Device->CreateQuery(&qDesc, &g_QueryBegin);
+    g_D3D11Device->CreateQuery(&qDesc, &g_QueryEnd);
+    qDesc.Query = D3D11_QUERY_TIMESTAMP_DISJOINT;
+    g_D3D11Device->CreateQuery(&qDesc, &g_QueryDisjoint);
+#endif // #if DO_COMPUTE
+
 
     // Main message loop
     MSG msg = { 0 };
@@ -150,10 +250,63 @@ static char s_Buffer[200];
 
 static void RenderFrame()
 {
+    static int s_FrameCount = 0;
     LARGE_INTEGER time1;
+
+#if DO_COMPUTE
     QueryPerformanceCounter(&time1);
     float t = float(clock()) / CLOCKS_PER_SEC;
-    static int s_FrameCount = 0;
+    UpdateTest(t, s_FrameCount, kBackbufferWidth, kBackbufferHeight);
+
+    g_BackbufferIndex = 1 - g_BackbufferIndex;
+    void* dataSpheres = alloca(g_SphereCount * g_ObjSize);
+    void* dataMaterials = alloca(g_SphereCount * g_MatSize);
+    ComputeParams dataParams;
+    GetSceneDesc(dataSpheres, dataMaterials, &dataParams.cam);
+
+    dataParams.sphereCount = g_SphereCount;
+    dataParams.screenWidth = kBackbufferWidth;
+    dataParams.screenHeight = kBackbufferHeight;
+    dataParams.frames = s_FrameCount;
+    dataParams.invWidth = 1.0f / kBackbufferWidth;
+    dataParams.invHeight = 1.0f / kBackbufferHeight;
+    float lerpFac = float(s_FrameCount) / float(s_FrameCount + 1);
+#if DO_ANIMATE
+    lerpFac *= DO_ANIMATE_SMOOTHING;
+#endif
+#if !DO_PROGRESSIVE
+    lerpFac = 0;
+#endif
+    dataParams.lerpFac = lerpFac;
+
+    g_D3D11Ctx->UpdateSubresource(g_DataSpheres, 0, NULL, dataSpheres, 0, 0);
+    g_D3D11Ctx->UpdateSubresource(g_DataMaterials, 0, NULL, dataMaterials, 0, 0);
+    g_D3D11Ctx->UpdateSubresource(g_DataParams, 0, NULL, &dataParams, 0, 0);
+
+    ID3D11ShaderResourceView* srvs[] = {
+        g_BackbufferIndex == 0 ? g_BackbufferSRV2 : g_BackbufferSRV,
+        g_SRVSpheres,
+        g_SRVMaterials,
+        g_SRVParams
+    };
+    g_D3D11Ctx->CSSetShaderResources(0, ARRAYSIZE(srvs), srvs);
+    ID3D11UnorderedAccessView* uavs[] = {
+        g_BackbufferIndex == 0 ? g_BackbufferUAV : g_BackbufferUAV2,
+        g_UAVCounter
+    };
+    g_D3D11Ctx->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, NULL);
+    g_D3D11Ctx->CSSetShader(g_ComputeShader, NULL, 0);
+    g_D3D11Ctx->Begin(g_QueryDisjoint);
+    g_D3D11Ctx->End(g_QueryBegin);
+    g_D3D11Ctx->Dispatch(kBackbufferWidth/kCSGroupSizeX, kBackbufferHeight/kCSGroupSizeY, 1);
+    g_D3D11Ctx->End(g_QueryEnd);
+    uavs[0] = NULL;
+    g_D3D11Ctx->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, NULL);
+    ++s_FrameCount;
+
+#else
+    QueryPerformanceCounter(&time1);
+    float t = float(clock()) / CLOCKS_PER_SEC;
     static size_t s_RayCounter = 0;
     int rayCount;
     UpdateTest(t, s_FrameCount, kBackbufferWidth, kBackbufferHeight);
@@ -190,15 +343,57 @@ static void RenderFrame()
         dst += mapped.RowPitch;
     }
     g_D3D11Ctx->Unmap(g_BackbufferTexture, 0);
+#endif
 
     g_D3D11Ctx->VSSetShader(g_VertexShader, NULL, 0);
     g_D3D11Ctx->PSSetShader(g_PixelShader, NULL, 0);
-    g_D3D11Ctx->PSSetShaderResources(0, 1, &g_BackbufferSRV);
+    g_D3D11Ctx->PSSetShaderResources(0, 1, g_BackbufferIndex == 0 ? &g_BackbufferSRV : &g_BackbufferSRV2);
     g_D3D11Ctx->PSSetSamplers(0, 1, &g_SamplerLinear);
     g_D3D11Ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
     g_D3D11Ctx->RSSetState(g_RasterState);
     g_D3D11Ctx->Draw(3, 0);
     g_D3D11SwapChain->Present(0, 0);
+
+#if DO_COMPUTE
+    g_D3D11Ctx->End(g_QueryDisjoint);
+
+    // get GPU times
+    while (g_D3D11Ctx->GetData(g_QueryDisjoint, NULL, 0, 0) == S_FALSE)
+    {
+        Sleep(0);
+    }
+    D3D10_QUERY_DATA_TIMESTAMP_DISJOINT tsDisjoint;
+    g_D3D11Ctx->GetData(g_QueryDisjoint, &tsDisjoint, sizeof(tsDisjoint), 0);
+    if (!tsDisjoint.Disjoint)
+    {
+        UINT64 tsBegin, tsEnd;
+        g_D3D11Ctx->GetData(g_QueryBegin, &tsBegin, sizeof(tsBegin), 0);
+        g_D3D11Ctx->GetData(g_QueryEnd, &tsEnd, sizeof(tsEnd), 0);
+        float s = float(tsEnd - tsBegin) / float(tsDisjoint.Frequency);
+
+        static uint64_t s_RayCounter;
+        D3D11_MAPPED_SUBRESOURCE mapped;
+        g_D3D11Ctx->Map(g_DataCounter, 0, D3D11_MAP_READ, 0, &mapped);
+        s_RayCounter += *(const int*)mapped.pData;
+        g_D3D11Ctx->Unmap(g_DataCounter, 0);
+        int zeroCount = 0;
+        g_D3D11Ctx->UpdateSubresource(g_DataCounter, 0, NULL, &zeroCount, 0, 0);
+
+        static float s_Time;
+        ++s_Count;
+        s_Time += s;
+        if (s_Count > 150)
+        {
+            s = s_Time / s_Count;
+            sprintf_s(s_Buffer, sizeof(s_Buffer), "%.2fms (%.1f FPS) %.1fMrays/s %.2fMrays/frame frames %i\n", s * 1000.0f, 1.f / s, s_RayCounter / s_Count / s * 1.0e-6f, s_RayCounter / s_Count * 1.0e-6f, s_FrameCount);
+            SetWindowTextA(g_Wnd, s_Buffer);
+            s_Count = 0;
+            s_Time = 0;
+            s_RayCounter = 0;
+        }
+
+    }
+#endif
 }
 
 

--- a/Cpp/Windows/TestWin.cpp
+++ b/Cpp/Windows/TestWin.cpp
@@ -358,17 +358,17 @@ static void RenderFrame()
     g_D3D11Ctx->End(g_QueryDisjoint);
 
     // get GPU times
-    while (g_D3D11Ctx->GetData(g_QueryDisjoint, NULL, 0, 0) == S_FALSE)
-    {
-        Sleep(0);
-    }
+    while (g_D3D11Ctx->GetData(g_QueryDisjoint, NULL, 0, 0) == S_FALSE) { Sleep(0); }
     D3D10_QUERY_DATA_TIMESTAMP_DISJOINT tsDisjoint;
     g_D3D11Ctx->GetData(g_QueryDisjoint, &tsDisjoint, sizeof(tsDisjoint), 0);
     if (!tsDisjoint.Disjoint)
     {
         UINT64 tsBegin, tsEnd;
-        g_D3D11Ctx->GetData(g_QueryBegin, &tsBegin, sizeof(tsBegin), 0);
-        g_D3D11Ctx->GetData(g_QueryEnd, &tsEnd, sizeof(tsEnd), 0);
+        // Note: on some GPUs/drivers, even when the disjoint query above already said "yeah I have data",
+        // might still not return "I have data" for timestamp queries before it.
+        while (g_D3D11Ctx->GetData(g_QueryBegin, &tsBegin, sizeof(tsBegin), 0) == S_FALSE) { Sleep(0); }
+        while (g_D3D11Ctx->GetData(g_QueryEnd, &tsEnd, sizeof(tsEnd), 0) == S_FALSE) { Sleep(0); }
+
         float s = float(tsEnd - tsBegin) / float(tsDisjoint.Frequency);
 
         static uint64_t s_RayCounter;
@@ -393,7 +393,7 @@ static void RenderFrame()
         }
 
     }
-#endif
+#endif // #if DO_COMPUTE
 }
 
 


### PR DESCRIPTION
Similarly to #5, a trivial impl for D3D11/HLSL.

AMD ThreadRipper, 3.4GHz, no SMT (C++ CPU 135 Mray/s):
- GeForce GTX 1080 Ti: 2780 Mray/s
- Radeon Pro WX 9100: 3700 Mray/s
- Radeon HD 7700: 417 Mray/s