### PR TITLE
C++: Simple SIMD / SoA experiment

### DIFF
--- a/Cpp/Mac/Renderer.mm
+++ b/Cpp/Mac/Renderer.mm
@@ -6,7 +6,7 @@
 #include "../Source/Maths.h"
 #include "../Source/Test.h"
 
-#define DO_COMPUTE 1
+#define DO_COMPUTE 0
 
 
 static const NSUInteger kMaxBuffersInFlight = 3;

--- a/Cpp/Mac/Test.xcodeproj/project.pbxproj
+++ b/Cpp/Mac/Test.xcodeproj/project.pbxproj
@@ -324,6 +324,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				GCC_FAST_MATH = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.aras.Test;
@@ -336,6 +337,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				GCC_FAST_MATH = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.aras.Test;

--- a/Cpp/Source/Maths.cpp
+++ b/Cpp/Source/Maths.cpp
@@ -58,7 +58,7 @@ int HitSpheres(const Ray& r, const SpheresSoA& spheres, float tMin, float tMax, 
         float ocY = r.orig.getY() - spheres.centerY[i];
         float ocZ = r.orig.getZ() - spheres.centerZ[i];
         float b = ocX * r.dir.getX() + ocY * r.dir.getY() + ocZ * r.dir.getZ();
-        float c = ocX * ocX + ocY * ocY + ocZ * ocZ - spheres.radius[i] * spheres.radius[i];
+        float c = ocX * ocX + ocY * ocY + ocZ * ocZ - spheres.sqRadius[i];
         float discr = b * b - c;
         if (discr > 0)
         {

--- a/Cpp/Source/Maths.cpp
+++ b/Cpp/Source/Maths.cpp
@@ -32,7 +32,7 @@ float3 RandomInUnitSphere(uint32_t& state)
     float3 p;
     do {
         p = 2.0*float3(RandomFloat01(state),RandomFloat01(state),RandomFloat01(state)) - float3(1,1,1);
-    } while (p.sqLength() >= 1.0);
+    } while (sqLength(p) >= 1.0);
     return p;
 }
 

--- a/Cpp/Source/Maths.cpp
+++ b/Cpp/Source/Maths.cpp
@@ -47,34 +47,46 @@ float3 RandomUnitVector(uint32_t& state)
 }
 
 
-bool HitSphere(const Ray& r, const Sphere& s, float tMin, float tMax, Hit& outHit)
+int HitSpheres(const Ray& r, const SpheresSoA& spheres, float tMin, float tMax, Hit& outHit)
 {
-    assert(s.invRadius == 1.0f/s.radius);
-    AssertUnit(r.dir);
-    float3 oc = r.orig - s.center;
-    float b = dot(oc, r.dir);
-    float c = dot(oc, oc) - s.radius*s.radius;
-    float discr = b*b - c;
-    if (discr > 0)
+    Hit tmpHit;
+    int id = -1;
+    float closest = tMax;
+    for (int i = 0; i < spheres.count; ++i)
     {
-        float discrSq = sqrtf(discr);
-        
-        float t = (-b - discrSq);
-        if (t < tMax && t > tMin)
+        float ocX = r.orig.getX() - spheres.centerX[i];
+        float ocY = r.orig.getY() - spheres.centerY[i];
+        float ocZ = r.orig.getZ() - spheres.centerZ[i];
+        float b = ocX * r.dir.getX() + ocY * r.dir.getY() + ocZ * r.dir.getZ();
+        float c = ocX * ocX + ocY * ocY + ocZ * ocZ - spheres.radius[i] * spheres.radius[i];
+        float discr = b * b - c;
+        if (discr > 0)
         {
-            outHit.pos = r.pointAt(t);
-            outHit.normal = (outHit.pos - s.center) * s.invRadius;
-            outHit.t = t;
-            return true;
-        }
-        t = (-b + discrSq);
-        if (t < tMax && t > tMin)
-        {
-            outHit.pos = r.pointAt(t);
-            outHit.normal = (outHit.pos - s.center) * s.invRadius;
-            outHit.t = t;
-            return true;
+            float discrSq = sqrtf(discr);
+
+            float t = (-b - discrSq);
+            if (t > tMin && t < tMax && t < closest)
+            {
+                id = i;
+                closest = t;
+                tmpHit.pos = r.pointAt(t);
+                tmpHit.normal = (tmpHit.pos - float3(spheres.centerX[i], spheres.centerY[i], spheres.centerZ[i])) * spheres.invRadius[i];
+                tmpHit.t = t;
+            }
+            else
+            {
+                t = (-b + discrSq);
+                if (t > tMin && t < tMax && t < closest)
+                {
+                    id = i;
+                    closest = t;
+                    tmpHit.pos = r.pointAt(t);
+                    tmpHit.normal = (tmpHit.pos - float3(spheres.centerX[i], spheres.centerY[i], spheres.centerZ[i])) * spheres.invRadius[i];
+                    tmpHit.t = t;
+                }
+            }
         }
     }
-    return false;
+    outHit = tmpHit;
+    return id;
 }

--- a/Cpp/Source/Maths.h
+++ b/Cpp/Source/Maths.h
@@ -222,7 +222,37 @@ struct Sphere
 };
 
 
-bool HitSphere(const Ray& r, const Sphere& s, float tMin, float tMax, Hit& outHit);
+// data for all spheres in a "structure of arrays" layout
+struct SpheresSoA
+{
+    SpheresSoA(int c)
+        : count(c)
+    {
+        centerX = new float[c];
+        centerY = new float[c];
+        centerZ = new float[c];
+        radius = new float[c];
+        invRadius = new float[c];
+    }
+    ~SpheresSoA()
+    {
+        delete[] centerX;
+        delete[] centerY;
+        delete[] centerZ;
+        delete[] radius;
+        delete[] invRadius;
+    }
+
+    float* centerX;
+    float* centerY;
+    float* centerZ;
+    float* radius;
+    float* invRadius;
+    int count;
+};
+
+
+int HitSpheres(const Ray& r, const SpheresSoA& spheres, float tMin, float tMax, Hit& outHit);
 
 float RandomFloat01(uint32_t& state);
 float3 RandomInUnitDisk(uint32_t& state);

--- a/Cpp/Source/Maths.h
+++ b/Cpp/Source/Maths.h
@@ -6,36 +6,145 @@
 
 #define kPI 3.1415926f
 
+#if defined(_MSC_VER)
+#define VM_INLINE __forceinline
+#else
+#define VM_INLINE __attribute__((unused, always_inline, nodebug)) inline
+#endif
+
+
+// SSE/SIMD vector largely based on http://www.codersnotes.com/notes/maths-lib-2016/
+#define FLOAT3_USE_SSE 1
+
+#if FLOAT3_USE_SSE
+
+#include <xmmintrin.h>
+
+// SHUFFLE3(v, 0,1,2) leaves the vector unchanged (v.xyz).
+// SHUFFLE3(v, 0,0,0) splats the X (v.xxx).
+#define SHUFFLE3(V, X,Y,Z) float3(_mm_shuffle_ps((V).m, (V).m, _MM_SHUFFLE(Z,Z,Y,X)))
+
+struct float3
+{
+    VM_INLINE float3() {}
+    VM_INLINE explicit float3(const float *p) { m = _mm_set_ps(p[2], p[2], p[1], p[0]); }
+    VM_INLINE explicit float3(float x, float y, float z) { m = _mm_set_ps(z, z, y, x); }
+    VM_INLINE explicit float3(__m128 v) { m = v; }
+    
+    VM_INLINE float getX() const { return _mm_cvtss_f32(m); }
+    VM_INLINE float getY() const { return _mm_cvtss_f32(_mm_shuffle_ps(m, m, _MM_SHUFFLE(1, 1, 1, 1))); }
+    VM_INLINE float getZ() const { return _mm_cvtss_f32(_mm_shuffle_ps(m, m, _MM_SHUFFLE(2, 2, 2, 2))); }
+    
+    VM_INLINE float3 yzx() const { return SHUFFLE3(*this, 1, 2, 0); }
+    VM_INLINE float3 zxy() const { return SHUFFLE3(*this, 2, 0, 1); }
+    
+    VM_INLINE void store(float *p) const { p[0] = getX(); p[1] = getY(); p[2] = getZ(); }
+    
+    void setX(float x)
+    {
+        m = _mm_move_ss(m, _mm_set_ss(x));
+    }
+    void setY(float y)
+    {
+        __m128 t = _mm_move_ss(m, _mm_set_ss(y));
+        t = _mm_shuffle_ps(t, t, _MM_SHUFFLE(3, 2, 0, 0));
+        m = _mm_move_ss(t, m);
+    }
+    void setZ(float z)
+    {
+        __m128 t = _mm_move_ss(m, _mm_set_ss(z));
+        t = _mm_shuffle_ps(t, t, _MM_SHUFFLE(3, 0, 1, 0));
+        m = _mm_move_ss(t, m);
+    }
+    
+    __m128 m;
+};
+
+typedef float3 bool3;
+
+VM_INLINE float3 operator+ (float3 a, float3 b) { a.m = _mm_add_ps(a.m, b.m); return a; }
+VM_INLINE float3 operator- (float3 a, float3 b) { a.m = _mm_sub_ps(a.m, b.m); return a; }
+VM_INLINE float3 operator* (float3 a, float3 b) { a.m = _mm_mul_ps(a.m, b.m); return a; }
+VM_INLINE float3 operator/ (float3 a, float3 b) { a.m = _mm_div_ps(a.m, b.m); return a; }
+VM_INLINE float3 operator* (float3 a, float b) { a.m = _mm_mul_ps(a.m, _mm_set1_ps(b)); return a; }
+VM_INLINE float3 operator/ (float3 a, float b) { a.m = _mm_div_ps(a.m, _mm_set1_ps(b)); return a; }
+VM_INLINE float3 operator* (float a, float3 b) { b.m = _mm_mul_ps(_mm_set1_ps(a), b.m); return b; }
+VM_INLINE float3 operator/ (float a, float3 b) { b.m = _mm_div_ps(_mm_set1_ps(a), b.m); return b; }
+VM_INLINE float3& operator+= (float3 &a, float3 b) { a = a + b; return a; }
+VM_INLINE float3& operator-= (float3 &a, float3 b) { a = a - b; return a; }
+VM_INLINE float3& operator*= (float3 &a, float3 b) { a = a * b; return a; }
+VM_INLINE float3& operator/= (float3 &a, float3 b) { a = a / b; return a; }
+VM_INLINE float3& operator*= (float3 &a, float b) { a = a * b; return a; }
+VM_INLINE float3& operator/= (float3 &a, float b) { a = a / b; return a; }
+VM_INLINE bool3 operator==(float3 a, float3 b) { a.m = _mm_cmpeq_ps(a.m, b.m); return a; }
+VM_INLINE bool3 operator!=(float3 a, float3 b) { a.m = _mm_cmpneq_ps(a.m, b.m); return a; }
+VM_INLINE bool3 operator< (float3 a, float3 b) { a.m = _mm_cmplt_ps(a.m, b.m); return a; }
+VM_INLINE bool3 operator> (float3 a, float3 b) { a.m = _mm_cmpgt_ps(a.m, b.m); return a; }
+VM_INLINE bool3 operator<=(float3 a, float3 b) { a.m = _mm_cmple_ps(a.m, b.m); return a; }
+VM_INLINE bool3 operator>=(float3 a, float3 b) { a.m = _mm_cmpge_ps(a.m, b.m); return a; }
+VM_INLINE float3 min(float3 a, float3 b) { a.m = _mm_min_ps(a.m, b.m); return a; }
+VM_INLINE float3 max(float3 a, float3 b) { a.m = _mm_max_ps(a.m, b.m); return a; }
+
+VM_INLINE float3 operator- (float3 a) { return float3(_mm_setzero_ps()) - a; }
+
+VM_INLINE float hmin(float3 v)
+{
+    v = min(v, SHUFFLE3(v, 1, 0, 2));
+    return min(v, SHUFFLE3(v, 2, 0, 1)).getX();
+}
+VM_INLINE float hmax(float3 v)
+{
+    v = max(v, SHUFFLE3(v, 1, 0, 2));
+    return max(v, SHUFFLE3(v, 2, 0, 1)).getX();
+}
+
+VM_INLINE float3 cross(float3 a, float3 b)
+{
+    // x  <-  a.y*b.z - a.z*b.y
+    // y  <-  a.z*b.x - a.x*b.z
+    // z  <-  a.x*b.y - a.y*b.x
+    // We can save a shuffle by grouping it in this wacky order:
+    return (a.zxy()*b - a*b.zxy()).zxy();
+}
+
+// Returns a 3-bit code where bit0..bit2 is X..Z
+VM_INLINE unsigned mask(float3 v) { return _mm_movemask_ps(v.m) & 7; }
+// Once we have a comparison, we can branch based on its results:
+VM_INLINE bool any(bool3 v) { return mask(v) != 0; }
+VM_INLINE bool all(bool3 v) { return mask(v) == 7; }
+
+VM_INLINE float3 clamp(float3 t, float3 a, float3 b) { return min(max(t, a), b); }
+VM_INLINE float sum(float3 v) { return v.getX() + v.getY() + v.getZ(); }
+VM_INLINE float dot(float3 a, float3 b) { return sum(a*b); }
+
+#else // #if FLOAT3_USE_SSE
+
 struct float3
 {
     float3() : x(0), y(0), z(0) {}
     float3(float x_, float y_, float z_) : x(x_), y(y_), z(z_) {}
-    
-    float sqLength() const { return x*x+y*y+z*z; }
-    float length() const { return sqrtf(x*x+y*y+z*z); }
-    void normalize() { float k = 1.0f / length(); x *= k; y *= k; z *= k; }
     
     float3 operator-() const { return float3(-x, -y, -z); }
     float3& operator+=(const float3& o) { x+=o.x; y+=o.y; z+=o.z; return *this; }
     float3& operator-=(const float3& o) { x-=o.x; y-=o.y; z-=o.z; return *this; }
     float3& operator*=(const float3& o) { x*=o.x; y*=o.y; z*=o.z; return *this; }
     float3& operator*=(float o) { x*=o; y*=o; z*=o; return *this; }
+    
+    VM_INLINE float getX() const { return x; }
+    VM_INLINE float getY() const { return y; }
+    VM_INLINE float getZ() const { return z; }
+    VM_INLINE void store(float *p) const { p[0] = getX(); p[1] = getY(); p[2] = getZ(); }
 
     float x, y, z;
 };
 
-inline void AssertUnit(const float3& v)
-{
-    assert(fabsf(v.sqLength() - 1.0f) < 0.01f);
-}
-
-inline float3 operator+(const float3& a, const float3& b) { return float3(a.x+b.x,a.y+b.y,a.z+b.z); }
-inline float3 operator-(const float3& a, const float3& b) { return float3(a.x-b.x,a.y-b.y,a.z-b.z); }
-inline float3 operator*(const float3& a, const float3& b) { return float3(a.x*b.x,a.y*b.y,a.z*b.z); }
-inline float3 operator*(const float3& a, float b) { return float3(a.x*b,a.y*b,a.z*b); }
-inline float3 operator*(float a, const float3& b) { return float3(a*b.x,a*b.y,a*b.z); }
-inline float dot(const float3& a, const float3& b) { return a.x*b.x+a.y*b.y+a.z*b.z; }
-inline float3 cross(const float3& a, const float3& b)
+VM_INLINE float3 operator+(const float3& a, const float3& b) { return float3(a.x+b.x,a.y+b.y,a.z+b.z); }
+VM_INLINE float3 operator-(const float3& a, const float3& b) { return float3(a.x-b.x,a.y-b.y,a.z-b.z); }
+VM_INLINE float3 operator*(const float3& a, const float3& b) { return float3(a.x*b.x,a.y*b.y,a.z*b.z); }
+VM_INLINE float3 operator*(const float3& a, float b) { return float3(a.x*b,a.y*b,a.z*b); }
+VM_INLINE float3 operator*(float a, const float3& b) { return float3(a*b.x,a*b.y,a*b.z); }
+VM_INLINE float dot(const float3& a, const float3& b) { return a.x*b.x+a.y*b.y+a.z*b.z; }
+VM_INLINE float3 cross(const float3& a, const float3& b)
 {
     return float3(
                   a.y*b.z - a.z*b.y,
@@ -43,11 +152,24 @@ inline float3 cross(const float3& a, const float3& b)
                   a.x*b.y - a.y*b.x
                   );
 }
-inline float3 normalize(const float3& v) { float k = 1.0f / v.length(); return float3(v.x*k, v.y*k, v.z*k); }
+#endif // #else of #if FLOAT3_USE_SSE
+
+VM_INLINE float length(float3 v) { return sqrtf(dot(v, v)); }
+VM_INLINE float sqLength(float3 v) { return dot(v, v); }
+VM_INLINE float3 normalize(float3 v) { return v * (1.0f / length(v)); }
+VM_INLINE float3 lerp(float3 a, float3 b, float t) { return a + (b-a)*t; }
+
+
+inline void AssertUnit(const float3& v)
+{
+    assert(fabsf(sqLength(v) - 1.0f) < 0.01f);
+}
+
 inline float3 reflect(const float3& v, const float3& n)
 {
     return v - 2*dot(v,n)*n;
 }
+
 inline bool refract(const float3& v, const float3& n, float nint, float3& outRefracted)
 {
     AssertUnit(v);
@@ -129,7 +251,7 @@ struct Camera
     Ray GetRay(float s, float t, uint32_t& state) const
     {
         float3 rd = lensRadius * RandomInUnitDisk(state);
-        float3 offset = u * rd.x + v * rd.y;
+        float3 offset = u * rd.getX() + v * rd.getY();
         return Ray(origin + offset, normalize(lowerLeftCorner + s*horizontal + t*vertical - origin - offset));
     }
     

--- a/Cpp/Source/Maths.h
+++ b/Cpp/Source/Maths.h
@@ -160,17 +160,17 @@ VM_INLINE float3 normalize(float3 v) { return v * (1.0f / length(v)); }
 VM_INLINE float3 lerp(float3 a, float3 b, float t) { return a + (b-a)*t; }
 
 
-inline void AssertUnit(const float3& v)
+inline void AssertUnit(float3 v)
 {
     assert(fabsf(sqLength(v) - 1.0f) < 0.01f);
 }
 
-inline float3 reflect(const float3& v, const float3& n)
+inline float3 reflect(float3 v, float3 n)
 {
     return v - 2*dot(v,n)*n;
 }
 
-inline bool refract(const float3& v, const float3& n, float nint, float3& outRefracted)
+inline bool refract(float3 v, float3 n, float nint, float3& outRefracted)
 {
     AssertUnit(v);
     float dt = dot(v, n);
@@ -192,7 +192,7 @@ inline float schlick(float cosine, float ri)
 struct Ray
 {
     Ray() {}
-    Ray(const float3& orig_, const float3& dir_) : orig(orig_), dir(dir_) { AssertUnit(dir); }
+    Ray(float3 orig_, float3 dir_) : orig(orig_), dir(dir_) { AssertUnit(dir); }
 
     float3 pointAt(float t) const { return orig + dir * t; }
     

--- a/Cpp/Source/Maths.h
+++ b/Cpp/Source/Maths.h
@@ -225,13 +225,12 @@ struct Sphere
 // data for all spheres in a "structure of arrays" layout
 struct SpheresSoA
 {
-    SpheresSoA(int c)
-        : count(c)
+    SpheresSoA(int c) : count(c)
     {
         centerX = new float[c];
         centerY = new float[c];
         centerZ = new float[c];
-        radius = new float[c];
+        sqRadius = new float[c];
         invRadius = new float[c];
     }
     ~SpheresSoA()
@@ -239,14 +238,13 @@ struct SpheresSoA
         delete[] centerX;
         delete[] centerY;
         delete[] centerZ;
-        delete[] radius;
+        delete[] sqRadius;
         delete[] invRadius;
     }
-
     float* centerX;
     float* centerY;
     float* centerZ;
-    float* radius;
+    float* sqRadius;
     float* invRadius;
     int count;
 };

--- a/Cpp/Source/Test.cpp
+++ b/Cpp/Source/Test.cpp
@@ -291,7 +291,7 @@ void UpdateTest(float time, int frameCount, int screenWidth, int screenHeight)
         s_SpheresSoA.centerX[i] = s.center.getX();
         s_SpheresSoA.centerY[i] = s.center.getY();
         s_SpheresSoA.centerZ[i] = s.center.getZ();
-        s_SpheresSoA.radius[i] = s.radius;
+        s_SpheresSoA.sqRadius[i] = s.radius * s.radius;
         s_SpheresSoA.invRadius[i] = s.invRadius;
     }
 

--- a/Cpp/Windows/TestCpu.vcxproj
+++ b/Cpp/Windows/TestCpu.vcxproj
@@ -90,6 +90,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <CallingConvention>VectorCall</CallingConvention>
+      <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -105,6 +106,7 @@
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <CallingConvention>VectorCall</CallingConvention>
+      <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -124,6 +126,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <CallingConvention>VectorCall</CallingConvention>
+      <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -145,6 +148,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <CallingConvention>VectorCall</CallingConvention>
+      <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Cpp/Windows/TestCpu.vcxproj
+++ b/Cpp/Windows/TestCpu.vcxproj
@@ -89,6 +89,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <CallingConvention>VectorCall</CallingConvention>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -103,6 +104,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <CallingConvention>VectorCall</CallingConvention>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -121,6 +123,7 @@
       <ExceptionHandling>false</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
+      <CallingConvention>VectorCall</CallingConvention>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -141,6 +144,7 @@
       <ExceptionHandling>false</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
+      <CallingConvention>VectorCall</CallingConvention>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Cpp/Windows/TestWin.cpp
+++ b/Cpp/Windows/TestWin.cpp
@@ -4,7 +4,7 @@
 #include <windows.h>
 #include <d3d11_1.h>
 
-#define DO_COMPUTE 1
+#define DO_COMPUTE 0
 
 
 #include <stdio.h>


### PR DESCRIPTION
* Let's try to use SSE for the `float3` struct, i.e. the "baby's first SIMD" approach :)
* Play around with SoA layout for all sphere data
* Play around with compiler settings wrt floating point math

PC: 135 -> 186 Mray/s
Mac: 38.7 -> 49.8 Mray/s

Largest win is _not_ from SSE `float3`, but from: 1) SoA layout of sphere data and 2) on MSVC, `fp:fast` setting.