### PR TITLE
Add thread support to Emscripten version

### DIFF
--- a/Cpp/Emscripten/build.bat
+++ b/Cpp/Emscripten/build.bat
@@ -1,0 +1,1 @@
+emcc -O3 -std=c++11 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s EXTRA_EXPORTED_RUNTIME_METHODS="['cwrap']" -o toypathtracer.js main.cpp ../Source/Maths.cpp ../Source/Test.cpp

--- a/Cpp/Emscripten/build_threads.bat
+++ b/Cpp/Emscripten/build_threads.bat
@@ -1,0 +1,1 @@
+emcc -O3 -std=c++11 -s PTHREAD_POOL_SIZE=%NUMBER_OF_PROCESSORS% -s USE_PTHREADS=1 -s WASM=1 -s TOTAL_MEMORY=268435456 -s EXTRA_EXPORTED_RUNTIME_METHODS="['cwrap']" -o toypathtracer.js main.cpp ../Source/Maths.cpp ../Source/Test.cpp ../Source/enkiTS/TaskScheduler.cpp ../Source/enkiTS/TaskScheduler_c.cpp

--- a/Cpp/Emscripten/build_threads.sh
+++ b/Cpp/Emscripten/build_threads.sh
@@ -1,0 +1,1 @@
+emcc -O3 -std=c++11 -s PTHREAD_POOL_SIZE=`nproc` -s USE_PTHREADS=1 -s WASM=1 -s TOTAL_MEMORY=268435456 -s EXTRA_EXPORTED_RUNTIME_METHODS='["cwrap"]' -o toypathtracer.js main.cpp ../Source/Maths.cpp ../Source/Test.cpp ../Source/enkiTS/TaskScheduler.cpp ../Source/enkiTS/TaskScheduler_c.cpp

--- a/Cpp/Emscripten/main.cpp
+++ b/Cpp/Emscripten/main.cpp
@@ -7,6 +7,18 @@
 #include "../Source/Test.h"
 
 EMSCRIPTEN_KEEPALIVE
+extern "C" void init()
+{
+    InitializeTest();
+}
+
+EMSCRIPTEN_KEEPALIVE
+extern "C" void done()
+{
+    ShutdownTest();
+}
+
+EMSCRIPTEN_KEEPALIVE
 extern "C" uint8_t* create_buffer(int width, int height)
 {
     return (uint8_t*)malloc(width * height * 4);

--- a/Cpp/Emscripten/toypathtracer.html
+++ b/Cpp/Emscripten/toypathtracer.html
@@ -55,6 +55,8 @@ Module.onRuntimeInitialized = _ =>
 {
     const api =
     {
+        init: Module.cwrap('init', '', []),
+        done: Module.cwrap('done', '', []),
         create_buffer: Module.cwrap('create_buffer', 'number', ['number', 'number']),
         destroy_buffer: Module.cwrap('destroy_buffer', '', ['number']),
         render: Module.cwrap('render', '', ['number', 'number', 'number', 'number']),
@@ -72,10 +74,17 @@ Module.onRuntimeInitialized = _ =>
     {
         var ctx = canvas.getContext('2d');
 
+        api.init();
         var pointer = api.create_buffer(width, height);
 
         var usub = new Uint8ClampedArray(Module.HEAP8.buffer, pointer, width*height*4);
-        var img = new ImageData(usub, width, height);
+
+        // TODO: better way to detect if threads can be used?
+        if (Module.HEAP8.buffer instanceof SharedArrayBuffer) {
+            var img = new ImageData(width, height);
+        } else {
+            var img = new ImageData(usub, width, height);
+        }
 
         var running = true;
         var start = null;
@@ -106,6 +115,10 @@ Module.onRuntimeInitialized = _ =>
 
         function draw()
         {
+            // TODO: better way to detect if threads can be used?
+            if (Module.HEAP8.buffer instanceof SharedArrayBuffer) {
+                img.data.set(usub);
+            }
             ctx.putImageData(img, 0, 0);
             window.requestAnimationFrame(step);
         }

--- a/Cpp/Source/Config.h
+++ b/Cpp/Source/Config.h
@@ -8,7 +8,11 @@
 
 #if defined(__EMSCRIPTEN__)
 #define CPU_CAN_DO_SIMD 0
+#ifdef __EMSCRIPTEN_PTHREADS__
+#define CPU_CAN_DO_THREADS 1
+#else
 #define CPU_CAN_DO_THREADS 0
+#endif
 #else
 #define CPU_CAN_DO_SIMD 1
 #define CPU_CAN_DO_THREADS 1


### PR DESCRIPTION
Results with Chrome 70 in Mray/s:

|      OS    |              CPU              | single-thread |    multi-thread   |
|------------|-------------------------------|---------------|-------------------|
| Windows 10 | Intel Core i7-7700, 3.6GHz    |      4.8      |  19.5 (8 threads) |
| ArchLinux  | 2x Intel Xeon E5-2698, 2.3GHz |      4.1      | ~37 (64 threads)  |


Requires enabling thread support in chrome://flags - `WebAssembly threads support`

Implementation with threads does a bit ugly copy on every frame to display image in Canvas - I could not figure out how to create ImageData from SharedArrayBuffer.

You probably will want to set PTHREAD_POOL_SIZE variable to reasonable amount of threads if deploying this to public. Currently it will use count of cpu cores on machine where it is being built as thread count to use.